### PR TITLE
bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Requirements
 Operations
 ----------
 
-* Use `python3 latextotext.py toto.tex` to transform a LaTeX file to a text file `toto.txt`. You will get an additionnal dictionnary `toto.dic`.
+* Use `python3 latextotext.py toto.tex` to transform a LaTeX file to a text file `toto.txt`. You will get an additional dictionary `toto.dic`.
 
 * Don't panic if you see lots of tags `€1234€`, they replace maths and LaTeX commands!  
 

--- a/bin/constants_perso.py
+++ b/bin/constants_perso.py
@@ -23,6 +23,7 @@ list_env_discard_perso = []    # like ['equation','align*']
 
 list_cmd_arg_discard_perso = ['ci','mybox']
 
-# 3. whether to remove Latex comments (lines starting by '%')
+# 3. whether to remove LaTeX comments (lines starting by '%')
 
 remove_comments = True
+# If set to False, be careful: LaTeX commands inside comments may cause bugs.

--- a/bin/latextotext.py
+++ b/bin/latextotext.py
@@ -82,6 +82,11 @@ if remove_comments:
     # done first, to prevent accidentally replacing commented Latex code later
     text_new = re.sub('%.*\n','',text_new)
 
+# Replace LaTeX newlines r'\\', including the optional argument, e.g. r'\\[-0.2cm]'.
+text_new = re.sub(r'\\\\(\[.*\])?',func_repl,text_new)
+# Done here to avoid a bug below when replacing r'\[ ... \]'.
+
+
 ### PART 1 - Replacement of maths ###
 
 # $$ ... $$
@@ -107,6 +112,7 @@ for env in list_env_discard + list_env_discard_perso:
 
 text_new = re.sub(r'\\begin\{(.+?)\}',func_repl,text_new, flags=re.MULTILINE|re.DOTALL)
 text_new = re.sub(r'\\end\{(.+?)\}',func_repl,text_new, flags=re.MULTILINE|re.DOTALL)
+
 
 ### PART 4 - Replacement of LaTeX commands with their argument ###
 

--- a/bin/latextotext.py
+++ b/bin/latextotext.py
@@ -94,7 +94,7 @@ text_new = re.sub(r'\\\((.+?)\\\)',func_repl,text_new, flags=re.MULTILINE|re.DOT
 text_new = re.sub(r'\\\[(.+?)\\\]',func_repl,text_new, flags=re.MULTILINE|re.DOTALL)
 
 
-### PART 2 - Replace \begin{env} and \end{env} but not its contents
+### PART 2 - Discard contents of some environments ###
 
 for env in list_env_discard + list_env_discard_perso:
     # escape *, e.g. replace r'align*' by r'align\*'
@@ -103,7 +103,7 @@ for env in list_env_discard + list_env_discard_perso:
     text_new = re.sub(str_env,func_repl,text_new, flags=re.MULTILINE|re.DOTALL)
 
 
-### PART 3 - Discard contents of some environments ###
+### PART 3 - Replace \begin{env} and \end{env} but not its contents
 
 text_new = re.sub(r'\\begin\{(.+?)\}',func_repl,text_new, flags=re.MULTILINE|re.DOTALL)
 text_new = re.sub(r'\\end\{(.+?)\}',func_repl,text_new, flags=re.MULTILINE|re.DOTALL)

--- a/bin/latextotext.py
+++ b/bin/latextotext.py
@@ -24,7 +24,7 @@ from constants_perso import *  # Personal customization
 parser = argparse.ArgumentParser(description='Conversion a LaTex file to a text file keeping apart commands and maths.')
 parser.add_argument('inputfile', help='input LaTeX filename')
 parser.add_argument('outputfile', nargs='?', help='output text filename')
-parser.add_argument('dicfile', nargs='?', help='output dictionnary filename')
+parser.add_argument('dicfile', nargs='?', help='output dictionary filename')
 options = parser.parse_args()
 
 tex_file = options.inputfile
@@ -59,23 +59,23 @@ fic_tex.close()
 # Replacement function pass as the replacement pattern in re.sub()
 
 count = 0           # counter for tags
-dictionnary = {}    # memorize tag: key=nb -> value=replacement
+dictionary = {}    # memorize tag: key=nb -> value=replacement
 
 def func_repl(m):
     """ Function called by sub as replacement pattern given by output
     Input: the pattern to be replaced
     Ouput: the new pattern
-    Action: also update the dictionnary of tags/replacement
+    Action: also update the dictionary of tags/replacement
     and increment the counter
     https://stackoverflow.com/questions/33962371"""
     global count
-    dictionnary[count] = m.group(0)  # Add old string found to the dic
+    dictionary[count] = m.group(0)  # Add old string found to the dic
     tag_str = tag+str(count)+tag     # tag = '€' is defined in 'constants.py'
     count += 1   
     return tag_str                   # New string for pattern replacement
 
 
-# Now we replace case by case math and command by tags
+# Now we replace case by case math and commands with tags
 text_new = text_all
 
 ### PART 1 - Replacement of maths ###
@@ -129,6 +129,6 @@ text_new = re.sub(r'\\[a-zA-Z]+',func_repl,text_new, flags=re.MULTILINE|re.DOTAL
 with open(txt_file, 'w', encoding='utf-8') as fic_txt:
     fic_txt.write(text_new)
 
-# Output: dictionnary file
+# Output: dictionary file
 with open(dic_file, 'w', encoding='utf-8') as fic_dic:
-    yaml.dump(dictionnary,fic_dic, default_flow_style=False,allow_unicode=True)
+    yaml.dump(dictionary,fic_dic, default_flow_style=False,allow_unicode=True)

--- a/bin/latextotext.py
+++ b/bin/latextotext.py
@@ -78,6 +78,10 @@ def func_repl(m):
 # Now we replace case by case math and commands with tags
 text_new = text_all
 
+if remove_comments:
+    # done first, to prevent accidentally replacing commented Latex code later
+    text_new = re.sub('%.*\n','',text_new)
+
 ### PART 1 - Replacement of maths ###
 
 # $$ ... $$
@@ -103,9 +107,6 @@ for env in list_env_discard + list_env_discard_perso:
 
 text_new = re.sub(r'\\begin\{(.+?)\}',func_repl,text_new, flags=re.MULTILINE|re.DOTALL)
 text_new = re.sub(r'\\end\{(.+?)\}',func_repl,text_new, flags=re.MULTILINE|re.DOTALL)
-
-if remove_comments:
-    text_new = re.sub('%.*\n','',text_new)
 
 ### PART 4 - Replacement of LaTeX commands with their argument ###
 


### PR DESCRIPTION
### Bug 1
 Si un commentaire "%LIGNE" contient une commande Latex, cette commande peut être prise au sérieux par latextotext.py au lieu d'être ignorée. Ça peut supprimer à tort de gros blocs de texte sans afficher de message d'erreur, rendant difficile la détection du bug.

Solution (commit [e5e03ab](https://github.com/arnbod/latex-to-text/pull/5/commits/e5e03abb19158a5d62a9ccaf7b2aba8cf0f7ee45)) : j'ai mis la suppression des commentaires avant les autres remplacements. Évidemment, ça ne résout pas le problème lorsque remove_comments vaut False.

### Bug 2
Problème similaire mais causé par une confusion entre la commande LaTeX \\\\[-0.2cm] et l'environnement math \[ ... \].
Solution : tentative [ff55c81](https://github.com/arnbod/latex-to-text/pull/5/commits/ff55c81cdcfb7ba238b99f71b4f066d356605c2f), recherche en cours.

### Bug 3
Le fichier `test-new-02.tex` est différent de `test-02.tex` : il contient encore des tags.
Solution : itérer dans `texttolatex.py` ? Recherche en cours.

Votre script m'est très utile, merci à vous !